### PR TITLE
Replace double quotes by single inside image tag

### DIFF
--- a/exportHTML.js
+++ b/exportHTML.js
@@ -8,7 +8,7 @@ const _analyzeLine = (alineAttrs, apool) => {
     const opIter = Changeset.opIterator(alineAttrs);
     if (opIter.hasNext()) {
       const op = opIter.next();
-      image = Changeset.opAttributeValue(op, 'img', apool);
+      image = Changeset.opAttributeValue(op, 'img', apool).replace(/"/g, "'");
     }
   }
 


### PR DESCRIPTION
When calling gethtml from the api.
With double quotes
![image](https://user-images.githubusercontent.com/5755057/103902706-3324df80-50fb-11eb-9373-3b6f92a7547a.png)
invalid image tag
![image](https://user-images.githubusercontent.com/5755057/103902758-433cbf00-50fb-11eb-8336-005eb057712d.png)


With single quotes
![image](https://user-images.githubusercontent.com/5755057/103902629-15f01100-50fb-11eb-9d92-652da4015023.png)
valid image tag
![image](https://user-images.githubusercontent.com/5755057/103902909-78e1a800-50fb-11eb-8496-010298435105.png)
