### PR TITLE
added remove images function

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -26,7 +26,8 @@
         "collectContentPre": "ep_image_upload/static/js/contentCollection",
         "collectContentPost": "ep_image_upload/static/js/contentCollection",
         "ccRegisterBlockElements": "ep_image_upload/static/js/contentCollection",
-        "loadSettings": "ep_image_upload/settings"
+        "loadSettings": "ep_image_upload/settings",
+        "padRemove": "ep_image_upload/index"
       }
     }
   ]

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const uuid = require('uuid');
 const path = require('path');
 const mimetypes = require('mime-db');
 const url = require('url');
+const fs = require('fs');
 
 /**
  * ClientVars hook
@@ -164,4 +165,17 @@ exports.expressConfigure = (hookName, context) => {
       req.pipe(busboy);
     }
   });
+};
+
+exports.padRemove = async (hookName, context) => {
+  // If storageType is local, delete the folder for the images
+  if (settings.ep_image_upload.storage.type === 'local') {
+    const dir = path.join(settings.ep_image_upload.storage.baseFolder, context.padID);
+
+    fs.rmdir(dir, { recursive: true }, (err) => {
+        if (err) {
+            throw err;
+        }
+    });
+  }
 };


### PR DESCRIPTION
If storage is set to `local` images get deleted, when a pad gets deleted.
This fixes #43