### PR TITLE
URL prefix to load images

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ Sample configuration in `settings.json` for using with local (disk) storage:
       "baseURL": "http://www.my-site.com/images/"
     },
     "fileTypes": ["jpeg", "jpg", "bmp", "gif","png"],
-    "maxFileSize": 5000000,
-    "urlPrefix": "/p/"
+    "maxFileSize": 5000000
   },
 ```
 
@@ -49,8 +48,6 @@ Sample configuration in `settings.json` for using with local (disk) storage:
 `maxFileSize` - file size in bytes. If not set there is no limit
 
 ```"baseURL"``` -> URL path to "baseFolder". For example if ```"baseFolder"``` is "/path/to/my_etherpad_folder/src/images"``` then ```http://myetherpad.com:9001/static/images/"```
-
-`urlPrefix` - Prepended to the URL to load the images
 
 ### Amazon S3 storage
 
@@ -66,8 +63,7 @@ Sample configuration in `settings.json` for using with Amazon S3:
       "baseFolder": "FOLDER_PATH"
     },
     "fileTypes": ["jpeg", "jpg", "bmp", "gif","png"],
-    "maxFileSize": 5000000,
-    "urlPrefix": "/p/"
+    "maxFileSize": 5000000
   },
 ```
 
@@ -78,5 +74,3 @@ Sample configuration in `settings.json` for using with Amazon S3:
 `fileTypes` - if left blank file mime-type is checked to match `image.*`
 
 `maxFileSize` - file size in bytes. If not set there is no limit
-
-`urlPrefix` - Prepended to the URL to load the images

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Sample configuration in `settings.json` for using with local (disk) storage:
       "baseURL": "http://www.my-site.com/images/"
     },
     "fileTypes": ["jpeg", "jpg", "bmp", "gif","png"],
-    "maxFileSize": 5000000
+    "maxFileSize": 5000000,
+    "urlPrefix": "/p/"
   },
 ```
 
@@ -48,6 +49,8 @@ Sample configuration in `settings.json` for using with local (disk) storage:
 `maxFileSize` - file size in bytes. If not set there is no limit
 
 ```"baseURL"``` -> URL path to "baseFolder". For example if ```"baseFolder"``` is "/path/to/my_etherpad_folder/src/images"``` then ```http://myetherpad.com:9001/static/images/"```
+
+`urlPrefix` - Prepended to the URL to load the images
 
 ### Amazon S3 storage
 
@@ -63,7 +66,8 @@ Sample configuration in `settings.json` for using with Amazon S3:
       "baseFolder": "FOLDER_PATH"
     },
     "fileTypes": ["jpeg", "jpg", "bmp", "gif","png"],
-    "maxFileSize": 5000000
+    "maxFileSize": 5000000,
+    "urlPrefix": "/p/"
   },
 ```
 
@@ -74,3 +78,5 @@ Sample configuration in `settings.json` for using with Amazon S3:
 `fileTypes` - if left blank file mime-type is checked to match `image.*`
 
 `maxFileSize` - file size in bytes. If not set there is no limit
+
+`urlPrefix` - Prepended to the URL to load the images

--- a/static/js/toolbar.js
+++ b/static/js/toolbar.js
@@ -90,7 +90,7 @@ exports.postToolbarInit = (hook, context) => {
         $('#imageUploadModalLoader').show();
         $.ajax({
           type: 'POST',
-          url: `/p/${clientVars.padId}/pluginfw/ep_image_upload/upload`,
+          url: `${clientVars.urlPrefix}${clientVars.padId}/pluginfw/ep_image_upload/upload`,
           xhr: () => {
             const myXhr = $.ajaxSettings.xhr();
 

--- a/static/js/toolbar.js
+++ b/static/js/toolbar.js
@@ -90,7 +90,7 @@ exports.postToolbarInit = (hook, context) => {
         $('#imageUploadModalLoader').show();
         $.ajax({
           type: 'POST',
-          url: `${clientVars.urlPrefix}${clientVars.padId}/pluginfw/ep_image_upload/upload`,
+          url: `${clientVars.padId}/pluginfw/ep_image_upload/upload`,
           xhr: () => {
             const myXhr = $.ajaxSettings.xhr();
 


### PR DESCRIPTION
I had the problem, that my ehterpad is hosted under `www.example.com/etherpad` so the hardcoded `/p/` prefix caused the images to be loaded from `www.example.com/p/` which does not existed. With the new setting I can set the prefix to `/etherpad/p/` which solves my problem