### PR TITLE
Add support for HTML imports via jsdom (Etherpad v1.8.15)

### DIFF
--- a/static/js/contentCollection.js
+++ b/static/js/contentCollection.js
@@ -2,19 +2,17 @@
 
 // When an image is detected give it a lineAttribute
 // of Image with the URL to the iamge
-exports.collectContentImage = (name, context) => {
-  const tname = context.tname;
-  const state = context.state;
-  const lineAttributes = state.lineAttributes;
-  if (tname === 'div' || tname === 'p') {
-    delete lineAttributes.img;
-  }
-  if (tname === 'img') {
-    // client
-    if (context.node.currentSrc) lineAttributes.img = context.node.currentSrc;
-    // server
-    if (context.node.attribs) lineAttributes.img = context.node.attribs.src;
-  }
+exports.collectContentImage = (hookName, {node, state: {lineAttributes}, tname}) => {
+  if (tname === 'div' || tname === 'p') delete lineAttributes.img;
+  if (tname !== 'img') return;
+  lineAttributes.img =
+      // Client-side. This will also be used for server-side HTML imports once jsdom adds support
+      // for HTMLImageElement.currentSrc.
+      node.currentSrc ||
+      // Server-side HTML imports using jsdom v16.6.0 (Etherpad v1.8.15).
+      node.src ||
+      // Server-side HTML imports using cheerio (Etherpad <= v1.8.14).
+      (node.attribs && node.attribs.src);
 };
 
 exports.collectContentPre = (name, context) => {


### PR DESCRIPTION
Etherpad v1.8.15 will replace cheerio with jsdom for HTML imports: https://github.com/ether/etherpad-lite/pull/4683

Update the content collector hook to support jsdom's slightly different API.