### PR TITLE
fixed display of error popup

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -15,7 +15,6 @@
         "collectContentPost": "ep_image_upload/static/js/contentCollection"
       },
       "hooks":{
-        "eejsBlock_styles": "ep_image_upload/index",
         "clientVars": "ep_image_upload/index",
         "eejsBlock_body": "ep_image_upload/index",
         "collectContentImage": "ep_image_upload/static/js/contentCollection",

--- a/index.js
+++ b/index.js
@@ -65,13 +65,6 @@ exports.eejsBlock_body = (hookName, args, cb) => {
   return cb();
 };
 
-exports.eejsBlock_styles = (hookName, args, cb) => {
-  const style = eejs.require('ep_image_upload/templates/styles.ejs');
-  args.content += style;
-
-  return cb();
-};
-
 const drainStream = (stream) => {
   stream.on('readable', stream.read.bind(stream));
 };

--- a/static/css/ep_image_upload.css
+++ b/static/css/ep_image_upload.css
@@ -5,7 +5,6 @@
     left: 0;
     margin-left: auto;
     margin-right: auto;
-    display: none;
     z-index: 1;
     max-height: 600px;
 }

--- a/static/css/ep_image_upload.css
+++ b/static/css/ep_image_upload.css
@@ -12,4 +12,4 @@
 #imageUploadModalError .error {
     color: #900;
     text-align: center;
-};
+}

--- a/static/js/clientHooks.js
+++ b/static/js/clientHooks.js
@@ -38,7 +38,10 @@ exports.aceDomLineProcessLineAttributes = (name, context) => {
   return [];
 };
 
-exports.aceEditorCSS = () => ['/ep_image_upload/static/css/ace.css'];
+exports.aceEditorCSS = () => [
+  '/ep_image_upload/static/css/ace.css',
+  '/ep_image_upload/static/css/ep_image_upload.css',
+];
 
 exports.aceInitialized = (hook, context) => {
   const editorInfo = context.editorInfo;

--- a/static/js/toolbar.js
+++ b/static/js/toolbar.js
@@ -30,7 +30,7 @@ const _isValid = (file) => {
     if (validMime === false) {
       const errorMessage = window._('ep_image_upload.error.fileType');
       $('#imageUploadModalError .error').html(errorMessage);
-      $('#imageUploadModalError').show();
+      $('#imageUploadModalError').addClass('popup-show');
 
       return false;
     }
@@ -39,7 +39,7 @@ const _isValid = (file) => {
   if (clientVars.ep_image_upload && file.size > clientVars.ep_image_upload.maxFileSize) {
     const errorMessage = window._('ep_image_upload.error.fileSize');
     $('#imageUploadModalError .error').html(errorMessage);
-    $('#imageUploadModalError').show();
+    $('#imageUploadModalError').addClass('popup-show');
 
     return false;
   }
@@ -51,7 +51,7 @@ const _isValid = (file) => {
 exports.postToolbarInit = (hook, context) => {
   const toolbar = context.toolbar;
   $('#closeErrorModalButton').on('click', () => {
-    $('#imageUploadModalError').hide();
+    $('#imageUploadModalError').removeClass('popup-show');
   });
   toolbar.registerCommand('imageUpload', () => {
     $(document).find('body').find('#imageInput').remove();
@@ -71,7 +71,7 @@ exports.postToolbarInit = (hook, context) => {
         return;
       }
       if (clientVars.ep_image_upload.storageType === 'base64') {
-        $('#imageUploadModalLoader').hide();
+        $('#imageUploadModalLoader').removeClass('popup-show');
         const reader = new FileReader();
         reader.readAsDataURL(file);
         reader.onload = () => {
@@ -87,7 +87,7 @@ exports.postToolbarInit = (hook, context) => {
 
         // add assoc key values, this will be posts values
         formData.append('file', file, file.name);
-        $('#imageUploadModalLoader').show();
+        $('#imageUploadModalLoader').addClass('popup-show');
         $.ajax({
           type: 'POST',
           url: `/p/${clientVars.padId}/pluginfw/ep_image_upload/upload`,
@@ -97,7 +97,7 @@ exports.postToolbarInit = (hook, context) => {
             return myXhr;
           },
           success: (data) => {
-            $('#imageUploadModalLoader').hide();
+            $('#imageUploadModalLoader').removeClass('popup-show');
             context.ace.callWithAce((ace) => {
               const imageLineNr = _handleNewLines(ace);
               ace.ace_addImage(imageLineNr, data);
@@ -115,9 +115,9 @@ exports.postToolbarInit = (hook, context) => {
               errorResponse = {message: error.responseText};
             }
 
-            $('#imageUploadModalLoader').hide();
+            $('#imageUploadModalLoader').removeClass('popup-show');
             $('#imageUploadModalError .error').html(errorResponse.message);
-            $('#imageUploadModalError').show();
+            $('#imageUploadModalError').addClass('popup-show');
           },
           async: true,
           data: formData,

--- a/templates/modal.ejs
+++ b/templates/modal.ejs
@@ -1,9 +1,13 @@
 <div id="imageUploadModalError" class="popup">
+  <div class="popup-content">
     <h2 class="error"></h2>
     <br>
     <button id="closeErrorModalButton">Close</button>
+  </div>
 </div>
 
 <div id="imageUploadModalLoader" class="popup">
+  <div class="popup-content">
     <p class="loadingAnimation"></p>
+  </div>
 </div>

--- a/templates/styles.ejs
+++ b/templates/styles.ejs
@@ -1,1 +1,0 @@
-<link rel="stylesheet" href="/static/plugins/ep_image_upload/static/css/ep_image_upload.css" type="text/css" />

--- a/templates/styles.ejs
+++ b/templates/styles.ejs
@@ -1,1 +1,0 @@
-<link rel="stylesheet" href="../static/plugins/ep_image_upload/static/css/ep_image_upload.css" type="text/css" />


### PR DESCRIPTION
Loading of `ep_image_upload/static/css/ep_image_upload.css` with style.ejs created a 404 on non root path hostings. So I changed the loading to the client hook `aceEditorCSS`.

The popups did not toggle with `.show()` and `.hide()` etherpad provides the css-class `popup-show` which toggles the visibility of popups. 

The popup had a transparent background, so I added a `popup-content` div