### PR TITLE
Fix backend tests to resolve the error `Error: Unable to create new Pad`

### DIFF
--- a/static/tests/backend/specs/exportHTML.js
+++ b/static/tests/backend/specs/exportHTML.js
@@ -2,20 +2,28 @@
 
 const common = require('ep_etherpad-lite/tests/backend/common');
 const randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
+import {generateJWTToken} from "ep_etherpad-lite/tests/backend/common";
 
 let agent;
 const apiKey = common.apiKey;
 const apiVersion = 1;
 
-const createPad = async (padID) => {
-  const res = await agent.get(`/api/${apiVersion}/createPad?apikey=${apiKey}&padID=${padID}`);
-  if (res.body.code !== 0) throw new Error('Unable to create new Pad');
+const createPad = async (padID, callback) => {
+  agent.get(`/api/${apiVersion}/createPad?&padID=${padID}`)
+    .set("Authorization", await generateJWTToken())
+    .end((err, res) => {
+      if (err || (res.body.code !== 0)) callback(new Error('Unable to create new Pad'));
+      callback(padID);
+    });
 };
 
-const setHTML = async (padID, html) => {
-  const res =
-      await agent.get(`/api/${apiVersion}/setHTML?apikey=${apiKey}&padID=${padID}&html=${html}`);
-  if (res.body.code !== 0) throw new Error('Unable to set pad HTML');
+const setHTML = async (padID, html, callback) => {
+  agent.get(`/api/${apiVersion}/setHTML?padID=${padID}&html=${html}`)
+    .set("Authorization", await generateJWTToken())
+    .end((err, res) => {
+      if (err || (res.body.code !== 0)) callback(new Error('Unable to set pad HTML'));
+      callback(null, padID);
+    });
 };
 
 describe(__filename, function () {
@@ -24,16 +32,19 @@ describe(__filename, function () {
   before(async function () { agent = await common.init(); });
 
   // create a new pad before each test run
-  beforeEach(async function () {
+  beforeEach(function (done) {
     padID = randomString(5);
-    await createPad(padID);
-    const uploadSVG =
+
+    createPad(padID, () => {
+      const uploadSVG =
         'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-    await setHTML(padID, `<html><body><img src="${uploadSVG}"></body></html>`);
+      setHTML(padID, `<html><body><img src="${uploadSVG}"></body></html>`, done);
+    });
   });
 
   it('returns HTML with img HTML tags', async function () {
-    const res = await agent.get(`/api/${apiVersion}/getHTML?apikey=${apiKey}&padID=${padID}`)
+    const res = await agent.get(`/api/${apiVersion}/getHTML?padID=${padID}`)
+        .set("Authorization", await generateJWTToken())
         .expect(200)
         .expect('Content-Type', /json/);
     if (!res.body.data.html.includes('<img')) throw new Error('No image tag detected');


### PR DESCRIPTION
The [backend tests of etherpad-lite](https://github.com/ether/etherpad-lite/actions/runs/9175232874/job/25234195816?pr=6396#step:13:1876) was reporting the error below:

```
  11) /home/runner/work/etherpad-lite/etherpad-lite/node_modules/.pnpm/ep_image_upload@1.0.105_ep_etherpad-lite@src/node_modules/ep_image_upload/static/tests/backend/specs/exportHTML.js
       "before each" hook for "returns HTML with img HTML tags":
     Error: Unable to create new Pad
      at createPad (/home/runner/work/etherpad-lite/etherpad-lite/node_modules/.pnpm/ep_image_upload@1.0.105_ep_etherpad-lite@src/node_modules/ep_image_upload/static/tests/backend/specs/exportHTML.js:12:34)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Context.<anonymous> (/home/runner/work/etherpad-lite/etherpad-lite/node_modules/.pnpm/ep_image_upload@1.0.105_ep_etherpad-lite@src/node_modules/ep_image_upload/static/tests/backend/specs/exportHTML.js:29:5)
```

The reason may be that the backend test is not compliant with the latest etherpad-lite test method. For example, [the latest test for ep_font_size](https://github.com/ether/ep_font_size/blob/a49f3ae90d66c27431db281403b296b8111345a0/static/tests/backend/specs/api/exportHTML.js) seems to give the token obtained from the utility function to the Authorization header.
So, I fixed the test by referring to the other test.